### PR TITLE
Add methods for appending Buildable objects to buffer.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 Cargo.lock
+target/

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -77,8 +77,12 @@ pub struct Builder<'a> {
 /// Error type for builder operations
 #[derive(Debug)]
 pub enum Error {
+    /// Tried to write data over the buffer bounds
     OutOfBounds(usize, Offset),
+    /// Index was not within buffer
     OffsetError(Offset),
+    /// Invalid data encountered while building
+    InvalidData,
 }
 
 impl core::error::Error for Error {}
@@ -95,6 +99,9 @@ impl fmt::Display for Error {
             }
             Error::OffsetError(idx) => {
                 write!(f, "Invalid index {}", idx)
+            }
+            Error::InvalidData => {
+                write!(f, "Invalid data")
             }
         }
     }


### PR DESCRIPTION
Adds two methods, `append()` and `append_all()`  to `Builder`. `append()` allows to add a `Buildable` to the end of buffer and `append_all()` can be used to append a slice of `Buildable`s to the end of the buffer. Both methods will call the `build()` method of buildable to write data to buffer. If error occurs while appending data, the index of buffer is reset back to where it was when `append()` or `append_all()` was called. 

Also add a new error type `Error::InvalidData` which allows the `build()` method of `Buildable` to signal that data was invalid and could not be written into buffer. 

